### PR TITLE
Dev feature user can display adoptions

### DIFF
--- a/app/Http/Controllers/AdopcionController.php
+++ b/app/Http/Controllers/AdopcionController.php
@@ -17,7 +17,6 @@ class AdopcionController extends Controller
    */
   public function index(): View
   {
-    Gate::authorize('viewAny', Adopcion::class);
     $adopciones = Adopcion::all();
     return view('layouts.adopciones.index', compact('adopciones'));
   }

--- a/app/Http/Controllers/AdopcionController.php
+++ b/app/Http/Controllers/AdopcionController.php
@@ -17,7 +17,11 @@ class AdopcionController extends Controller
    */
   public function index(): View
   {
-    $adopciones = Adopcion::all();
+    if (auth()->user()->role == 'admin') {
+      $adopciones = Adopcion::all();
+    } else {
+      $adopciones = Adopcion::where('user_id', auth()->user()->id)->get();
+    }
     return view('layouts.adopciones.index', compact('adopciones'));
   }
 
@@ -26,7 +30,6 @@ class AdopcionController extends Controller
    */
   public function create(Tortuga $tortuga): View
   {
-    Gate::authorize('create', Adopcion::class);
     return view('layouts.adopciones.create', compact('tortuga'));
   }
 

--- a/app/Policies/AdopcionPolicy.php
+++ b/app/Policies/AdopcionPolicy.php
@@ -32,7 +32,7 @@ class AdopcionPolicy
    */
   public function create(User $user): bool|Response
   {
-    return \auth()->check();
+    return true;
   }
 
   /**

--- a/app/Policies/AdopcionPolicy.php
+++ b/app/Policies/AdopcionPolicy.php
@@ -13,10 +13,7 @@ class AdopcionPolicy
    */
   public function viewAny(User $user): bool|Response
   {
-    if ($user->role == 'admin') {
-      return true;
-    }
-    return Response::deny('You are not alloweed to check information about adoptions.');
+    return true;
   }
 
   /**

--- a/resources/views/layouts/adopciones/create.blade.php
+++ b/resources/views/layouts/adopciones/create.blade.php
@@ -10,7 +10,7 @@
     <input type="hidden" name="tortuga_id" value="{{ $tortuga->id }}">
     <div class="mb-4">
       <label for="motivation" class="block text-gray-700">Motivation:</label>
-      <textarea name="motivation" id="motivation" rows="4" class="block w-full mt-1 border-gray-300 rounded-md shadow-sm" minlength="10" maxlength="255" placeholder="Why do you want to adopt {{ $tortuga->name }}? Please, provide as much information as possible. We need to know {{ $tortuga->name }} will be in good hands.">@if(old('motivation')){{ old('motivation') }}@endif</textarea>
+      <textarea name="motivation" id="motivation" rows="4" class="block w-full mt-1 border-gray-300 rounded-md shadow-sm" minlength="10" maxlength="255" placeholder="Why do you want to adopt {{ $tortuga->name }}? Please, provide some details (255 characters max). We need to know {{ $tortuga->name }} will be in good hands. ">@if(old('motivation')){{ old('motivation') }}@endif</textarea>
       @error('motivation')
       <p class="text-red-500 text-xs mt-1">Please, we need more details.</p>
       @enderror

--- a/resources/views/layouts/adopciones/index.blade.php
+++ b/resources/views/layouts/adopciones/index.blade.php
@@ -12,7 +12,9 @@
           <th class="py-2 px-4 border text-center">User</th>
           <th class="py-2 px-4 border text-center">Turtle</th>
           <th class="py-2 px-4 border text-center">Adoption Date</th>
+          @if (auth()->user()->role == 'admin')
           <th class="py-2 px-4 border text-center">Actions</th>
+          @endif
         </tr>
       </thead>
       <tbody>
@@ -21,6 +23,7 @@
           <td class="py-2 px-4 border text-center">{{ $adopcion->user->name }}</td>
           <td class="py-2 px-4 border text-center">{{ $adopcion->tortuga->name }}</td>
           <td class="py-2 px-4 border text-center">{{ $adopcion->created_at->format('d M Y') }}</td>
+          @if (auth()->user()->role == 'admin')
           <td class="py-2 px-4 border text-center">
             <a href="{{ route('adopciones.edit', ['adopcion' => $adopcion->id]) }}" class="bg-blue-400 hover:bg-blue-500 text-white font-bold py-1 px-3 rounded transition-colors duration-200">Edit</a>
             <form action="{{ route('adopciones.destroy', $adopcion->id) }}" method="POST" style="display:inline;">
@@ -29,6 +32,8 @@
               <button type="submit" class="bg-red-300 hover:bg-red-400 text-white font-bold py-1 px-3 rounded transition-colors duration-200" onclick="return confirm('Are you sure you want to delete this adoption?')">Delete</button>
             </form>
           </td>
+          @endif
+
         </tr>
         @endforeach
       </tbody>

--- a/resources/views/layouts/tortugas/index.blade.php
+++ b/resources/views/layouts/tortugas/index.blade.php
@@ -7,13 +7,17 @@
 @auth
 @if (auth()->user()->role == 'admin')
 <div class="flex flex-col items-center space-y-4">
-  <a href="{{ route('tortugas.create') }}"
-    class="bg-blue-300 hover:bg-blue-400 text-white font-bold py-2 px-4 rounded transition-colors duration-200">
+  <a href="{{ route('tortugas.create') }}" class="bg-blue-300 hover:bg-blue-400 text-white font-bold py-2 px-4 rounded transition-colors duration-200">
     Add new information about a turtle
   </a>
-  <a href="{{ route('adopciones.index') }}"
-    class="bg-pink-300 hover:bg-pink-400 text-white font-bold py-2 px-4 rounded transition-colors duration-200">
+  <a href="{{ route('adopciones.index') }}" class="bg-pink-300 hover:bg-pink-400 text-white font-bold py-2 px-4 rounded transition-colors duration-200">
     Check the adoptions
+  </a>
+</div>
+@else
+<div class="flex flex-col items-center space-y-4">
+  <a href="{{ route('adopciones.index') }}" class="bg-pink-300 hover:bg-pink-400 text-white font-bold py-2 px-4 rounded transition-colors duration-200">
+    Check your adoptions
   </a>
 </div>
 @endif
@@ -29,8 +33,7 @@
         <h2 class="text-xl font-bold mb-2">{{ $tortuga->name }}</h2>
         <p>Age: {{ $tortuga->age }} years</p>
         <p class="text-gray-600 mb-4">Birthday: {{ $tortuga->birthday }}</p>
-        <a href="{{ route('tortugas.show', $tortuga) }}"
-          class="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded">
+        <a href="{{ route('tortugas.show', $tortuga) }}" class="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded">
           View Details
         </a>
       </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,8 +19,10 @@ Route::resources([
   'tortugas' => TortugaController::class
 ]);
 
-Route::get('/adopciones/create/{tortuga}', [AdopcionController::class, 'create'])->name('adopciones.create');
+Route::middleware('auth')->group(function () {
+  Route::get('/adopciones/create/{tortuga}', [AdopcionController::class, 'create'])->name('adopciones.create');
 
-Route::resource('adopciones', AdopcionController::class)->except(['create'])->parameters([
-  'adopciones' => 'adopcion'
-]);
+  Route::resource('adopciones', AdopcionController::class)->except(['create'])->parameters([
+    'adopciones' => 'adopcion'
+  ]);
+});


### PR DESCRIPTION
Protegemos las adopciones bajo el paraguas del middleware auth para no abusar tanto de las policies. Ahora los usuarios pueden ver un listado con sus adopciones.